### PR TITLE
Fix `prepublish` script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "react-with-context",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "Pass context into React components and replace for React.withContext",
   "main": "bin/WithContext.js",
   "types": "WithContext.d.ts",
   "scripts": {
     "test": "jest",
     "build": "babel src -d bin",
-    "prepublish": "npm build && npm test"
+    "prepublish": "npm run build && npm run test"
   },
   "files": [
     "WithContext.d.ts",


### PR DESCRIPTION
Unfortunately my change to the prepublish script broke the release process. 

If consumers try to `import`/`require` the package, it fails to resolve. Upon investigation of `node_modules`, it turns out that the latest published version does not ship with the compiled code (see file explorer in image below)

The `prepublish` script fails to generate the compiled code, so when the package is published, that code is missing and consumers can't use it.

![publish-error](https://cloud.githubusercontent.com/assets/2515134/23144960/c02e4c04-f790-11e6-89b4-7e0aa6bfcab2.jpg)

This fixes that, so if you merge and republish, everything should work just fine.